### PR TITLE
Fixed a problem with the series expansion of erf() and removed a broken link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,10 +211,7 @@ place. Ondřej Čertík is still active in the community but is too busy
 with work and family to play a lead development role.
 
 Since then, a lot more people have joined the development and some
-people have also left. You can see the full list in doc/src/aboutus.rst,
-or online at:
-
-<https://docs.sympy.org/dev/aboutus.html#sympy-development-team>
+people have also left. You can see the full list in doc/src/aboutus.rst.
 
 The git history goes back to 2007 when development moved from svn to hg.
 To see the history before that point, look at

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1959,17 +1959,19 @@ class Mul(Expr, AssocOp):
                     lt = term.leadterm(x)
                 except ValueError:
                     return term, S.Zero
+                except PoleError:
+                    return term, S.Zero
             return lt
 
         ords = []
 
         try:
             for t in self.args:
-                coeff, exp = t.leadterm(x)
+                coeff, exp = coeff_exp(t, x) # changed from leadterm to coeff_exp
                 if not coeff.has(x):
                     ords.append((t, exp))
                 else:
-                    raise ValueError
+                    raise ValueError("Leading coefficient has a x within it.")
 
             n0 = sum(t[1] for t in ords if t[1].is_number)
             facs = []

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -406,3 +406,15 @@ def test_issue_24266():
 
 def test_issue_26856():
     raises(ValueError, lambda: (2**x).series(x, oo, -1))
+
+def test_issue_27109():
+    from sympy import symbols, exp, sqrt, pi, oo, erf, series
+
+    x = symbols('x', positive=True)
+
+    f2 = 2 * erf(x)
+    s2 = series(f2, x, x0=oo, n=3)
+
+    expected_s2 = -((2 / x) + O(x**(-3), (x, oo))) * (exp(-x**2) / sqrt(pi)) + 2
+
+    assert s2.equals(expected_s2)


### PR DESCRIPTION
Fixes issue #27109
https://github.com/sympy/sympy/issues/27109

Updated README.md with a broken link

Added  a new except block along with changing a line that used leadterm to coeff_expt.

NO ENTRY for Release Notes per SYMPY documentation.
